### PR TITLE
Add support for multiple buckets

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -193,6 +193,10 @@ var ioFlags = []cli.Flag{
 		Value: appName + "-benchmark-bucket",
 		Usage: "Bucket to use for benchmark data. ALL DATA WILL BE DELETED IN BUCKET!",
 	},
+	cli.BoolFlag{
+		Name:  "bucket-per-client",
+		Usage: "For distributed benchmarking, give each client a unique bucket",
+	},
 	cli.StringFlag{
 		Name:  "host-select",
 		Value: string(hostSelectTypeWeighed),
@@ -290,11 +294,29 @@ func getCommon(ctx *cli.Context, src func() generator.Source) bench.Common {
 		rpsLimiter = rate.NewLimiter(rate.Limit(rpsLimit), 1)
 	}
 
+	var bucketFunc func() string
+	if ctx.Bool("bucket-per-client") {
+		host, err := os.Hostname()
+		if err != nil {
+			fatalIf(probe.NewError(err), "unable to get client hostname")
+		}
+		bucketName := fmt.Sprintf("%s-%s", ctx.String("bucket"), host)
+
+		bucketFunc = func() string {
+			return bucketName
+		}
+	} else {
+		bucketName := ctx.String("bucket")
+		bucketFunc = func() string {
+			return bucketName
+		}
+	}
+
 	return bench.Common{
 		Client:        newClient(ctx),
 		Concurrency:   ctx.Int("concurrent"),
 		Source:        src,
-		Bucket:        ctx.String("bucket"),
+		Bucket:        bucketFunc,
 		Location:      ctx.String("region"),
 		PutOpts:       putOpts(ctx),
 		DiscardOutput: ctx.Bool("stress"),

--- a/pkg/bench/delete.go
+++ b/pkg/bench/delete.go
@@ -52,18 +52,18 @@ func (d *Delete) Prepare(ctx context.Context) error {
 		cl, done := d.Client()
 
 		// ensure the bucket exist
-		found, err := cl.BucketExists(ctx, d.Bucket)
+		found, err := cl.BucketExists(ctx, d.Bucket())
 		if err != nil {
 			return err
 		}
 		if !found {
-			return fmt.Errorf("bucket %s does not exist and --list-existing has been set", d.Bucket)
+			return fmt.Errorf("bucket %s does not exist and --list-existing has been set", d.Bucket())
 		}
 
 		// list all objects
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		objectCh := cl.ListObjects(ctx, d.Bucket, minio.ListObjectsOptions{
+		objectCh := cl.ListObjects(ctx, d.Bucket(), minio.ListObjectsOptions{
 			Prefix:    d.ListPrefix,
 			Recursive: !d.ListFlat,
 		})
@@ -85,7 +85,7 @@ func (d *Delete) Prepare(ctx context.Context) error {
 			}
 		}
 		if len(d.objects) == 0 {
-			return (fmt.Errorf("no objects found for bucket %s", d.Bucket))
+			return (fmt.Errorf("no objects found for bucket %s", d.Bucket()))
 		}
 		done()
 		d.Collector = NewCollector()
@@ -144,7 +144,7 @@ func (d *Delete) Prepare(ctx context.Context) error {
 
 				opts.ContentType = obj.ContentType
 				op.Start = time.Now()
-				res, err := client.PutObject(ctx, d.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				res, err := client.PutObject(ctx, d.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
@@ -255,7 +255,7 @@ func (d *Delete) Start(ctx context.Context, wait chan struct{}) (Operations, err
 
 				op.Start = time.Now()
 				// RemoveObjectsWithContext will split any batches > 1000 into separate requests.
-				errCh := client.RemoveObjects(nonTerm, d.Bucket, objects, minio.RemoveObjectsOptions{})
+				errCh := client.RemoveObjects(nonTerm, d.Bucket(), objects, minio.RemoveObjectsOptions{})
 
 				// Wait for errCh to close.
 				for {

--- a/pkg/bench/fanout.go
+++ b/pkg/bench/fanout.go
@@ -98,7 +98,7 @@ func (u *Fanout) Start(ctx context.Context, wait chan struct{}) (Operations, err
 				}
 
 				op.Start = time.Now()
-				res, err := client.PutObjectFanOut(nonTerm, u.Bucket, obj.Reader, opts)
+				res, err := client.PutObjectFanOut(nonTerm, u.Bucket(), obj.Reader, opts)
 				op.End = time.Now()
 				if err != nil {
 					u.Error("upload error: ", err)

--- a/pkg/bench/get.go
+++ b/pkg/bench/get.go
@@ -57,18 +57,18 @@ func (g *Get) Prepare(ctx context.Context) error {
 		cl, done := g.Client()
 
 		// ensure the bucket exist
-		found, err := cl.BucketExists(ctx, g.Bucket)
+		found, err := cl.BucketExists(ctx, g.Bucket())
 		if err != nil {
 			return err
 		}
 		if !found {
-			return (fmt.Errorf("bucket %s does not exist and --list-existing has been set", g.Bucket))
+			return (fmt.Errorf("bucket %s does not exist and --list-existing has been set", g.Bucket()))
 		}
 
 		// list all objects
 		ctx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		objectCh := cl.ListObjects(ctx, g.Bucket, minio.ListObjectsOptions{
+		objectCh := cl.ListObjects(ctx, g.Bucket(), minio.ListObjectsOptions{
 			WithVersions: g.Versions > 1,
 			Prefix:       g.ListPrefix,
 			Recursive:    !g.ListFlat,
@@ -112,7 +112,7 @@ func (g *Get) Prepare(ctx context.Context) error {
 			}
 		}
 		if len(g.objects) == 0 {
-			return (fmt.Errorf("no objects found for bucket %s", g.Bucket))
+			return (fmt.Errorf("no objects found for bucket %s", g.Bucket()))
 		}
 		done()
 		return nil
@@ -125,7 +125,7 @@ func (g *Get) Prepare(ctx context.Context) error {
 	if g.Versions > 1 {
 		cl, done := g.Client()
 		if !g.Versioned {
-			err := cl.EnableVersioning(ctx, g.Bucket)
+			err := cl.EnableVersioning(ctx, g.Bucket())
 			if err != nil {
 				return err
 			}
@@ -184,7 +184,7 @@ func (g *Get) Prepare(ctx context.Context) error {
 
 					opts.ContentType = obj.ContentType
 					op.Start = time.Now()
-					res, err := client.PutObject(ctx, g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+					res, err := client.PutObject(ctx, g.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 					op.End = time.Now()
 					if err != nil {
 						err := fmt.Errorf("upload error: %w", err)
@@ -307,7 +307,7 @@ func (g *Get) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 				if g.Versions > 1 {
 					opts.VersionID = obj.VersionID
 				}
-				o, err := client.GetObject(nonTerm, g.Bucket, obj.Name, opts)
+				o, err := client.GetObject(nonTerm, g.Bucket(), obj.Name, opts)
 				if err != nil {
 					g.Error("download error:", err)
 					op.Err = err.Error()

--- a/pkg/bench/list.go
+++ b/pkg/bench/list.go
@@ -51,7 +51,7 @@ func (d *List) Prepare(ctx context.Context) error {
 	if d.Versions > 1 {
 		cl, done := d.Client()
 		if !d.Versioned {
-			err := cl.EnableVersioning(ctx, d.Bucket)
+			err := cl.EnableVersioning(ctx, d.Bucket())
 			if err != nil {
 				return err
 			}
@@ -125,7 +125,7 @@ func (d *List) Prepare(ctx context.Context) error {
 
 					opts.ContentType = obj.ContentType
 					op.Start = time.Now()
-					res, err := client.PutObject(ctx, d.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+					res, err := client.PutObject(ctx, d.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 					op.End = time.Now()
 					if err != nil {
 						err := fmt.Errorf("upload error: %w", err)
@@ -219,7 +219,7 @@ func (d *List) Start(ctx context.Context, wait chan struct{}) (Operations, error
 				op.Start = time.Now()
 
 				// List all objects with prefix
-				listCh := client.ListObjects(nonTerm, d.Bucket, minio.ListObjectsOptions{
+				listCh := client.ListObjects(nonTerm, d.Bucket(), minio.ListObjectsOptions{
 					WithMetadata: d.Metadata,
 					Prefix:       objs[0].Prefix,
 					Recursive:    true,

--- a/pkg/bench/mixed.go
+++ b/pkg/bench/mixed.go
@@ -188,7 +188,7 @@ func (g *Mixed) Prepare(ctx context.Context) error {
 				obj := src.Object()
 				client, clDone := g.Client()
 				opts.ContentType = obj.ContentType
-				res, err := client.PutObject(ctx, g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				res, err := client.PutObject(ctx, g.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
 					g.Error(err)
@@ -273,7 +273,7 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 					op.Start = time.Now()
 					var err error
 					getOpts.VersionID = obj.VersionID
-					o, err := client.GetObject(nonTerm, g.Bucket, obj.Name, getOpts)
+					o, err := client.GetObject(nonTerm, g.Bucket(), obj.Name, getOpts)
 					fbr.r = o
 					if err != nil {
 						g.Error("download error:", err)
@@ -313,7 +313,7 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 						Endpoint: client.EndpointURL().String(),
 					}
 					op.Start = time.Now()
-					res, err := client.PutObject(nonTerm, g.Bucket, obj.Name, obj.Reader, obj.Size, putOpts)
+					res, err := client.PutObject(nonTerm, g.Bucket(), obj.Name, obj.Reader, obj.Size, putOpts)
 					op.End = time.Now()
 					if err != nil {
 						g.Error("upload error:", err)
@@ -346,7 +346,7 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 					}
 
 					op.Start = time.Now()
-					err := client.RemoveObject(nonTerm, g.Bucket, obj.Name, minio.RemoveObjectOptions{VersionID: obj.VersionID})
+					err := client.RemoveObject(nonTerm, g.Bucket(), obj.Name, minio.RemoveObjectOptions{VersionID: obj.VersionID})
 					op.End = time.Now()
 					clDone()
 					if err != nil {
@@ -367,7 +367,7 @@ func (g *Mixed) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 					}
 					op.Start = time.Now()
 					var err error
-					objI, err := client.StatObject(nonTerm, g.Bucket, obj.Name, statOpts)
+					objI, err := client.StatObject(nonTerm, g.Bucket(), obj.Name, statOpts)
 					if err != nil {
 						g.Error("stat error: ", err)
 						op.Err = err.Error()

--- a/pkg/bench/multipart.go
+++ b/pkg/bench/multipart.go
@@ -58,7 +58,7 @@ func (g *Multipart) InitOnce(ctx context.Context) error {
 	cl, done := g.Client()
 	c := minio.Core{Client: cl}
 	defer done()
-	uploadID, err := c.NewMultipartUpload(ctx, g.Bucket, g.ObjName, g.PutOpts)
+	uploadID, err := c.NewMultipartUpload(ctx, g.Bucket(), g.ObjName, g.PutOpts)
 	if err != nil {
 		return err
 	}
@@ -133,7 +133,7 @@ func (g *Multipart) Prepare(ctx context.Context) error {
 					DisableContentSha256: g.PutOpts.DisableContentSha256,
 				}
 				op.Start = time.Now()
-				res, err := core.PutObjectPart(ctx, g.Bucket, obj.Name, g.UploadID, partN, obj.Reader, obj.Size, mpopts)
+				res, err := core.PutObjectPart(ctx, g.Bucket(), obj.Name, g.UploadID, partN, obj.Reader, obj.Size, mpopts)
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
@@ -187,7 +187,7 @@ func (g *Multipart) AfterPrepare(ctx context.Context) error {
 	}
 	console.Eraseline()
 	console.Infof("\rCompleting Object with %d parts...", len(parts))
-	_, err := c.CompleteMultipartUpload(ctx, g.Bucket, g.ObjName, g.UploadID, parts, g.PutOpts)
+	_, err := c.CompleteMultipartUpload(ctx, g.Bucket(), g.ObjName, g.UploadID, parts, g.PutOpts)
 	return err
 }
 
@@ -240,7 +240,7 @@ func (g *Multipart) Start(ctx context.Context, wait chan struct{}) (Operations, 
 
 				op.Start = time.Now()
 				opts.PartNumber = part
-				o, err := client.GetObject(nonTerm, g.Bucket, obj.Name, opts)
+				o, err := client.GetObject(nonTerm, g.Bucket(), obj.Name, opts)
 				if err != nil {
 					g.Error("download error:", err)
 					op.Err = err.Error()

--- a/pkg/bench/put.go
+++ b/pkg/bench/put.go
@@ -101,11 +101,11 @@ func (u *Put) Start(ctx context.Context, wait chan struct{}) (Operations, error)
 				var err error
 				var res minio.UploadInfo
 				if !u.PostObject {
-					res, err = client.PutObject(nonTerm, u.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+					res, err = client.PutObject(nonTerm, u.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 				} else {
 					op.OpType = http.MethodPost
 					var verID string
-					verID, err = u.postPolicy(ctx, client, u.Bucket, obj)
+					verID, err = u.postPolicy(ctx, client, u.Bucket(), obj)
 					if err == nil {
 						res.Size = obj.Size
 						res.VersionID = verID

--- a/pkg/bench/retention.go
+++ b/pkg/bench/retention.go
@@ -47,7 +47,7 @@ func (g *Retention) Prepare(ctx context.Context) error {
 	}
 	cl, done := g.Client()
 	if !g.Versioned {
-		err := cl.EnableVersioning(ctx, g.Bucket)
+		err := cl.EnableVersioning(ctx, g.Bucket())
 		if err != nil {
 			return err
 		}
@@ -103,7 +103,7 @@ func (g *Retention) Prepare(ctx context.Context) error {
 
 					opts.ContentType = obj.ContentType
 					op.Start = time.Now()
-					res, err := client.PutObject(ctx, g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+					res, err := client.PutObject(ctx, g.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 					op.End = time.Now()
 					if err != nil {
 						err := fmt.Errorf("upload error: %w", err)
@@ -192,7 +192,7 @@ func (g *Retention) Start(ctx context.Context, wait chan struct{}) (Operations, 
 				opts.RetainUntilDate = &t
 				opts.Mode = &mode
 				opts.GovernanceBypass = true
-				err := client.PutObjectRetention(nonTerm, g.Bucket, obj.Name, opts)
+				err := client.PutObjectRetention(nonTerm, g.Bucket(), obj.Name, opts)
 				if err != nil {
 					g.Error("put retention error:", err)
 					op.Err = err.Error()

--- a/pkg/bench/s3zip.go
+++ b/pkg/bench/s3zip.go
@@ -102,13 +102,13 @@ func (g *S3Zip) Prepare(ctx context.Context) error {
 
 	// TODO: Add header to index.
 	// g.PutOpts.Set("x-minio-extract", "true")
-	_, err := client.PutObject(ctx, g.Bucket, g.ZipObjName, pr, -1, g.PutOpts)
+	_, err := client.PutObject(ctx, g.Bucket(), g.ZipObjName, pr, -1, g.PutOpts)
 	pr.CloseWithError(err)
 	if err == nil {
 		var opts minio.GetObjectOptions
 		opts.Set("x-minio-extract", "true")
 
-		oi, err2 := client.GetObject(ctx, g.Bucket, path.Join(g.ZipObjName, g.objects[0].Name), opts)
+		oi, err2 := client.GetObject(ctx, g.Bucket(), path.Join(g.ZipObjName, g.objects[0].Name), opts)
 		if err2 != nil {
 			err = err2
 		}
@@ -171,7 +171,7 @@ func (g *S3Zip) Start(ctx context.Context, wait chan struct{}) (Operations, erro
 				op.Start = time.Now()
 				opts.Set("x-minio-extract", "true")
 
-				o, err := client.GetObject(nonTerm, g.Bucket, op.File, opts)
+				o, err := client.GetObject(nonTerm, g.Bucket(), op.File, opts)
 				if err != nil {
 					g.Error("download error:", err)
 					op.Err = err.Error()

--- a/pkg/bench/select.go
+++ b/pkg/bench/select.go
@@ -90,7 +90,7 @@ func (g *Select) Prepare(ctx context.Context) error {
 
 				opts.ContentType = obj.ContentType
 				op.Start = time.Now()
-				res, err := client.PutObject(ctx, g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				res, err := client.PutObject(ctx, g.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 				op.End = time.Now()
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
@@ -174,7 +174,7 @@ func (g *Select) Start(ctx context.Context, wait chan struct{}) (Operations, err
 
 				op.Start = time.Now()
 				var err error
-				o, err := client.SelectObjectContent(nonTerm, g.Bucket, obj.Name, opts)
+				o, err := client.SelectObjectContent(nonTerm, g.Bucket(), obj.Name, opts)
 				fbr.r = o
 				if err != nil {
 					g.Error("download error: ", err)

--- a/pkg/bench/snowball.go
+++ b/pkg/bench/snowball.go
@@ -165,7 +165,7 @@ func (s *Snowball) Start(ctx context.Context, wait chan struct{}) (Operations, e
 				op.Start = time.Now()
 				tarLength := int64(buf.Len())
 				// fmt.Println(op.Size, "->", tarLength, math.Round(100*float64(tarLength)/float64(op.Size)), "%")
-				res, err := client.PutObject(nonTerm, s.Bucket, obj.Name+".tar", &buf, tarLength, opts)
+				res, err := client.PutObject(nonTerm, s.Bucket(), obj.Name+".tar", &buf, tarLength, opts)
 				op.End = time.Now()
 				if err != nil {
 					s.Error("upload error: ", err)

--- a/pkg/bench/stat.go
+++ b/pkg/bench/stat.go
@@ -50,7 +50,7 @@ func (g *Stat) Prepare(ctx context.Context) error {
 	if g.Versions > 1 {
 		cl, done := g.Client()
 		if !g.Versioned {
-			err := cl.EnableVersioning(ctx, g.Bucket)
+			err := cl.EnableVersioning(ctx, g.Bucket())
 			if err != nil {
 				return err
 			}
@@ -109,7 +109,7 @@ func (g *Stat) Prepare(ctx context.Context) error {
 
 					opts.ContentType = obj.ContentType
 					op.Start = time.Now()
-					res, err := client.PutObject(ctx, g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+					res, err := client.PutObject(ctx, g.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 					op.End = time.Now()
 					if err != nil {
 						err := fmt.Errorf("upload error: %w", err)
@@ -195,7 +195,7 @@ func (g *Stat) Start(ctx context.Context, wait chan struct{}) (Operations, error
 				if g.Versions > 1 {
 					opts.VersionID = obj.VersionID
 				}
-				objI, err := client.StatObject(nonTerm, g.Bucket, obj.Name, opts)
+				objI, err := client.StatObject(nonTerm, g.Bucket(), obj.Name, opts)
 				if err != nil {
 					g.Error("StatObject error: ", err)
 					op.Err = err.Error()

--- a/pkg/bench/versioned.go
+++ b/pkg/bench/versioned.go
@@ -53,7 +53,7 @@ func (g *Versioned) Prepare(ctx context.Context) error {
 	}
 	if !g.Versioned {
 		cl, done := g.Client()
-		err := cl.EnableVersioning(ctx, g.Bucket)
+		err := cl.EnableVersioning(ctx, g.Bucket())
 		done()
 		if err != nil {
 			return err
@@ -92,7 +92,7 @@ func (g *Versioned) Prepare(ctx context.Context) error {
 				obj := src.Object()
 				client, clDone := g.Client()
 				opts.ContentType = obj.ContentType
-				res, err := client.PutObject(ctx, g.Bucket, obj.Name, obj.Reader, obj.Size, opts)
+				res, err := client.PutObject(ctx, g.Bucket(), obj.Name, obj.Reader, obj.Size, opts)
 				if err != nil {
 					err := fmt.Errorf("upload error: %w", err)
 					g.Error(err)
@@ -176,7 +176,7 @@ func (g *Versioned) Start(ctx context.Context, wait chan struct{}) (Operations, 
 					op.Start = time.Now()
 					var err error
 					getOpts.VersionID = obj.VersionID
-					fbr.r, err = client.GetObject(nonTerm, g.Bucket, obj.Name, getOpts)
+					fbr.r, err = client.GetObject(nonTerm, g.Bucket(), obj.Name, getOpts)
 					if err != nil {
 						g.Error("download error: ", err)
 						op.Err = err.Error()
@@ -214,7 +214,7 @@ func (g *Versioned) Start(ctx context.Context, wait chan struct{}) (Operations, 
 					}
 
 					op.Start = time.Now()
-					res, err := client.PutObject(nonTerm, g.Bucket, obj.Name, obj.Reader, obj.Size, putOpts)
+					res, err := client.PutObject(nonTerm, g.Bucket(), obj.Name, obj.Reader, obj.Size, putOpts)
 					op.End = time.Now()
 					if err != nil {
 						g.Error("upload error: ", err)
@@ -249,7 +249,7 @@ func (g *Versioned) Start(ctx context.Context, wait chan struct{}) (Operations, 
 						Endpoint: client.EndpointURL().String(),
 					}
 					op.Start = time.Now()
-					err := client.RemoveObject(nonTerm, g.Bucket, obj.Name, minio.RemoveObjectOptions{VersionID: obj.VersionID})
+					err := client.RemoveObject(nonTerm, g.Bucket(), obj.Name, minio.RemoveObjectOptions{VersionID: obj.VersionID})
 					op.End = time.Now()
 					clDone()
 					if err != nil {
@@ -271,7 +271,7 @@ func (g *Versioned) Start(ctx context.Context, wait chan struct{}) (Operations, 
 					op.Start = time.Now()
 					var err error
 					statOpts.VersionID = obj.VersionID
-					objI, err := client.StatObject(nonTerm, g.Bucket, obj.Name, statOpts)
+					objI, err := client.StatObject(nonTerm, g.Bucket(), obj.Name, statOpts)
 					if err != nil {
 						g.Error("stat error:", err)
 						op.Err = err.Error()


### PR DESCRIPTION
When running distributed benchmarks, you can now use `--bucket-per-client` to have each client use a unique bucket. This can be used to compare performance of one bucket vs. many buckets.