### PR TITLE
Fixed issue where distributed warp hangs at end

### DIFF
--- a/cli/benchmark.go
+++ b/cli/benchmark.go
@@ -102,7 +102,12 @@ func runBench(ctx *cli.Context, b bench.Benchmark) error {
 		b.GetCommon().ClientIdx = ab.clientIdx
 		return runClientBenchmark(ctx, b, ab)
 	}
+
 	if done, err := runServerBenchmark(ctx, b); done || err != nil {
+		// Close all extra output channels so the benchmark will terminate
+		for _, out := range b.GetCommon().ExtraOut {
+			close(out)
+		}
 		fatalIf(probe.NewError(err), "Error running remote benchmark")
 		return nil
 	}


### PR DESCRIPTION
When running distributed warp with influxdb, the app would always hang at the end of each run. This is because the channel used to send operations to Influx isn't used on the initiator process and thus, never gets closed. The app then hangs on the global wait group for the influx goroutine to complete.