### PR TITLE
InfluxDB Logging Changes

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -70,7 +70,6 @@ var globalFlags = []cli.Flag{
 		Value:  "",
 		Hidden: false,
 	},
-
 }
 
 var profileFlags = []cli.Flag{
@@ -278,6 +277,10 @@ var ioFlags = []cli.Flag{
 		Name:   "influxdb",
 		EnvVar: appNameUC + "_INFLUXDB_CONNECT",
 		Usage:  "Send operations to InfluxDB. Specify as 'http://<token>@<hostname>:<port>/<bucket>/<org>'",
+	},
+	cli.BoolFlag{
+		Name:  "no-aggregate",
+		Usage: "disable aggregation of results when sending to InfluxDB",
 	},
 	cli.Float64Flag{
 		Name:  "rps-limit",

--- a/cli/influx.go
+++ b/cli/influx.go
@@ -236,7 +236,7 @@ func (a aggregatedStats) point(op bench.Operation, noAggregate bool) *write.Poin
 	p := influxdb2.NewPointWithMeasurement("warp")
 	p.AddTag("op", op.OpType)
 
-	if !noAggregate {
+	if noAggregate {
 		p.AddField("requests", 1)
 		p.AddField("objects", op.ObjPerOp)
 		p.AddField("bytes_total", op.Size)
@@ -249,6 +249,7 @@ func (a aggregatedStats) point(op bench.Operation, noAggregate bool) *write.Poin
 			errs = 1
 		}
 		p.AddField("errors", errs)
+		p.SetTime(op.End)
 	} else {
 		p.AddField("requests", a.ops)
 		p.AddField("objects", a.objects)

--- a/cli/influx.go
+++ b/cli/influx.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -56,6 +57,14 @@ func newInfluxDB(ctx *cli.Context, wg *sync.WaitGroup) chan<- bench.Operation {
 	}
 	tags["warp_id"] = pRandASCII(8)
 
+	// Tag with the hostname of the client.
+	// Useful to ensure clients are performing the same.
+	hostname, err := os.Hostname()
+	if err != nil {
+		fatalIf(probe.NewError(err), "unable to determine hostname")
+	}
+	tags["client"] = hostname
+
 	// Create a new client using an InfluxDB server base URL and an authentication token
 	serverURL := u.Scheme + "://" + u.Host
 	client := influxdb2.NewClientWithOptions(serverURL, token, influxdb2.DefaultOptions().SetMaxRetryTime(1000).SetMaxRetries(2))
@@ -74,6 +83,9 @@ func newInfluxDB(ctx *cli.Context, wg *sync.WaitGroup) chan<- bench.Operation {
 		errorIf(probe.NewError(&err), "unable to write to influxdb")
 		return false
 	})
+
+	noAggregate := ctx.Bool("no-aggregate")
+
 	ch := make(chan bench.Operation, 10000)
 	wg.Add(1)
 	go func() {
@@ -101,8 +113,8 @@ func newInfluxDB(ctx *cli.Context, wg *sync.WaitGroup) chan<- bench.Operation {
 			host[op.OpType] = hostStats
 
 			// Send
-			pTot := total.point(op)
-			pHost := hostStats.point(op)
+			pTot := total.point(op, noAggregate)
+			pHost := hostStats.point(op, noAggregate)
 
 			for key, tag := range tags {
 				pTot.AddTag(key, tag)
@@ -220,16 +232,32 @@ func (a *aggregatedStats) add(o bench.Operation) {
 	}
 }
 
-func (a aggregatedStats) point(op bench.Operation) *write.Point {
+func (a aggregatedStats) point(op bench.Operation, noAggregate bool) *write.Point {
 	p := influxdb2.NewPointWithMeasurement("warp")
 	p.AddTag("op", op.OpType)
-	p.AddField("requests", a.ops)
-	p.AddField("objects", a.objects)
-	p.AddField("bytes_total", a.bytes)
-	p.AddField("errors", a.errors)
-	p.AddField("request_total_secs", float64(a.reqDur)/float64(time.Second))
-	if a.ttfb > 0 {
-		p.AddField("request_ttfb_total_secs", float64(a.ttfb)/float64(time.Second))
+
+	if !noAggregate {
+		p.AddField("requests", 1)
+		p.AddField("objects", op.ObjPerOp)
+		p.AddField("bytes_total", op.Size)
+		p.AddField("request_total_secs", float64(op.End.Sub(op.Start))/float64(time.Second))
+		if op.FirstByte != nil {
+			p.AddField("request_ttfb_avg_secs", float64(op.FirstByte.Sub(op.Start))/float64(time.Second))
+		}
+		errs := 0
+		if op.Err != "" {
+			errs = 1
+		}
+		p.AddField("errors", errs)
+	} else {
+		p.AddField("requests", a.ops)
+		p.AddField("objects", a.objects)
+		p.AddField("bytes_total", a.bytes)
+		p.AddField("errors", a.errors)
+		p.AddField("request_total_secs", float64(a.reqDur)/float64(time.Second))
+		if a.ttfb > 0 {
+			p.AddField("request_ttfb_total_secs", float64(a.ttfb)/float64(time.Second))
+		}
 	}
 	return p
 }


### PR DESCRIPTION
Added a couple new features to InfluxDB logging

* Added the 'host' tag to the data points. This will allow you to see if there are any performance variations by host.
* Added the `--no-aggregate` flag. The regular implementation of logging to InfluxDB reports the cumulative stats (e.g. _total_ objects written, and _total_ bytes written), so the number continuously increases. This makes it hard to plot realtime rates in grafana. With `--no-aggregate`, only the raw numbers are posted so you can easily have grafana plot the rates (e.g. byte/s or ops/s).