### PR TITLE
Revamp Influx stats, improve random performance

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -282,10 +282,6 @@ var ioFlags = []cli.Flag{
 		EnvVar: appNameUC + "_INFLUXDB_CONNECT",
 		Usage:  "Send operations to InfluxDB. Specify as 'http://<token>@<hostname>:<port>/<bucket>/<org>'",
 	},
-	cli.BoolFlag{
-		Name:  "no-aggregate",
-		Usage: "disable aggregation of results when sending to InfluxDB",
-	},
 	cli.Float64Flag{
 		Name:  "rps-limit",
 		Value: 0,

--- a/cli/generator.go
+++ b/cli/generator.go
@@ -76,6 +76,8 @@ func newGenSource(ctx *cli.Context, sizeField string) func() generator.Source {
 		g = generator.WithRandomData()
 	case "csv":
 		g = generator.WithCSV().Size(25, 1000)
+	case "randomLite":
+		g = generator.WithCircularRandomData()
 	default:
 		err := errors.New("unknown generator type:" + ctx.String("obj.generator"))
 		fatal(probe.NewError(err), "Invalid -generator parameter")

--- a/cli/influx.go
+++ b/cli/influx.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	influxdb2 "github.com/influxdata/influxdb-client-go/v2"
+	influxapi "github.com/influxdata/influxdb-client-go/v2/api"
 	"github.com/influxdata/influxdb-client-go/v2/api/http"
 	"github.com/influxdata/influxdb-client-go/v2/api/write"
 	"github.com/minio/cli"
@@ -84,69 +85,113 @@ func newInfluxDB(ctx *cli.Context, wg *sync.WaitGroup) chan<- bench.Operation {
 		return false
 	})
 
-	noAggregate := ctx.Bool("no-aggregate")
-
 	ch := make(chan bench.Operation, 10000)
 	wg.Add(1)
 	go func() {
-		defer func() {
-			writeAPI.Flush()
-			wg.Done()
-		}()
+
 		hosts := make(map[string]map[string]aggregatedStats, 100)
 		totalOp := make(map[string]aggregatedStats, 5)
-		for op := range ch {
-			host := hosts[op.Endpoint]
-			var hostStats aggregatedStats
-			if host == nil {
-				host = make(map[string]aggregatedStats, 5)
-				hosts[op.Endpoint] = host
-			} else {
-				hostStats = host[op.OpType]
-			}
-			total := totalOp[op.OpType]
-			hostStats.add(op)
-			total.add(op)
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		defer wg.Done()
 
-			// Store
-			totalOp[op.OpType] = total
-			host[op.OpType] = hostStats
-
-			// Send
-			pTot := total.point(op, noAggregate)
-			pHost := hostStats.point(op, noAggregate)
-
-			for key, tag := range tags {
-				pTot.AddTag(key, tag)
-				pHost.AddTag(key, tag)
-			}
-			pHost.AddTag("endpoint", op.Endpoint)
-			writeAPI.WritePoint(pHost)
-			writeAPI.WritePoint(pTot)
-		}
-		// Send summaries
-		for host, ops := range hosts {
-			for op, stats := range ops {
-				p := stats.summary(op)
-
-				for key, tag := range tags {
-					p.AddTag(key, tag)
+		for {
+			select {
+			case op, ok := <-ch:
+				if !ok {
+					// Channel closed, flush remaining data
+					flushData(hosts, totalOp, tags, writeAPI)
+					sendSummaries(hosts, totalOp, tags, writeAPI)
+					writeAPI.Flush()
+					return
 				}
-				p.AddTag("endpoint", host)
-				writeAPI.WritePoint(p)
-			}
-		}
-		for op, stats := range totalOp {
-			p := stats.summary(op)
 
-			for key, tag := range tags {
-				p.AddTag(key, tag)
+				host := hosts[op.Endpoint]
+				var hostStats aggregatedStats
+				if host == nil {
+					host = make(map[string]aggregatedStats, 5)
+					hosts[op.Endpoint] = host
+				} else {
+					hostStats = host[op.OpType]
+				}
+				total := totalOp[op.OpType]
+				hostStats.add(op)
+				total.add(op)
+
+				// Store
+				totalOp[op.OpType] = total
+				host[op.OpType] = hostStats
+
+			case <-ticker.C:
+				flushData(hosts, totalOp, tags, writeAPI)
 			}
-			p.AddTag("endpoint", "")
-			writeAPI.WritePoint(p)
 		}
 	}()
 	return ch
+}
+
+func sendSummaries(hosts map[string]map[string]aggregatedStats, totalOp map[string]aggregatedStats,
+	tags map[string]string, writeAPI influxapi.WriteAPI) {
+
+	// Send summaries for each host
+	for host, ops := range hosts {
+		for op, stats := range ops {
+			p := stats.summary(op)
+			for key, tag := range tags {
+				p.AddTag(key, tag)
+			}
+			p.AddTag("endpoint", host)
+			writeAPI.WritePoint(p)
+		}
+	}
+
+	// Send summaries for total operations
+	for op, stats := range totalOp {
+		p := stats.summary(op)
+		for key, tag := range tags {
+			p.AddTag(key, tag)
+		}
+		p.AddTag("endpoint", "")
+		writeAPI.WritePoint(p)
+	}
+}
+
+func flushData(hosts map[string]map[string]aggregatedStats, totalOp map[string]aggregatedStats, tags map[string]string, writeAPI influxapi.WriteAPI) {
+	for endpoint, hostData := range hosts {
+		for opType, hostStats := range hostData {
+			if hostStats.incr.ops == 0 {
+				// Don't write empty results.
+				continue
+			}
+			pHost := hostStats.point(bench.Operation{OpType: opType})
+			for key, tag := range tags {
+				pHost.AddTag(key, tag)
+			}
+			pHost.AddTag("endpoint", endpoint)
+			writeAPI.WritePoint(pHost)
+
+			// Reset only incremental stats
+			hostStats.incr = aggregatedStats{}.incr
+			hosts[endpoint][opType] = hostStats
+		}
+	}
+
+	for opType, totalStats := range totalOp {
+		if totalStats.incr.ops == 0 {
+			// Don't write empty results.
+			continue
+		}
+		pTot := totalStats.point(bench.Operation{OpType: opType})
+		for key, tag := range tags {
+			pTot.AddTag(key, tag)
+		}
+		pTot.AddTag("endpoint", "")
+		writeAPI.WritePoint(pTot)
+
+		// Reset only incremental stats
+		totalStats.incr = aggregatedStats{}.incr
+		totalOp[opType] = totalStats
+	}
 }
 
 func parseInfluxURL(ctx *cli.Context) (*url.URL, error) {
@@ -185,102 +230,108 @@ func parseInfluxURL(ctx *cli.Context) (*url.URL, error) {
 }
 
 type aggregatedStats struct {
-	bytes   int64
-	objects int
-	ops     int
-	errors  int
+	// Incremental stats (reset every second)
+	incr struct {
+		bytes   int64
+		objects int
+		ops     int
+		errors  int
+		reqDur  time.Duration
+		ttfb    time.Duration
+	}
 
-	// requests
-	reqDur time.Duration
-	reqMin time.Duration
-	reqMax time.Duration
+	// Total stats (accumulated over the entire run)
+	total struct {
+		bytes   int64
+		objects int
+		ops     int
+		errors  int
+		reqDur  time.Duration
+		ttfb    time.Duration
+	}
 
-	// time to first byte
-	ttfb    time.Duration
+	// These remain as before, tracking min/max for the entire run
+	reqMin  time.Duration
+	reqMax  time.Duration
 	ttfbMin time.Duration
 	ttfbMax time.Duration
 }
 
 func (a *aggregatedStats) add(o bench.Operation) {
-	a.ops++
+	// Update incremental stats
+	a.incr.ops++
+	a.incr.bytes += o.Size
+	a.incr.objects += o.ObjPerOp
+
+	// Update total stats
+	a.total.ops++
+	a.total.bytes += o.Size
+	a.total.objects += o.ObjPerOp
+
 	if o.Err != "" {
-		// Do not add more
-		a.errors++
+		a.incr.errors++
+		a.total.errors++
 		return
 	}
 
-	a.bytes += o.Size
-	a.objects += o.ObjPerOp
-
 	dur := o.End.Sub(o.Start)
-	a.reqDur += dur
+	a.incr.reqDur += dur
+	a.total.reqDur += dur
+
 	if dur > a.reqMax {
 		a.reqMax = dur
 	}
 	if a.reqMin == 0 || dur < a.reqMin {
 		a.reqMin = dur
 	}
+
 	if o.FirstByte != nil {
 		ttfb := o.FirstByte.Sub(o.Start)
-		a.ttfb += ttfb
+		a.incr.ttfb += ttfb
+		a.total.ttfb += ttfb
+
 		if ttfb > a.ttfbMax {
 			a.ttfbMax = ttfb
 		}
-		if a.ttfbMin == 0 || dur < a.ttfbMin {
-			a.ttfbMin = dur
+		if a.ttfbMin == 0 || ttfb < a.ttfbMin {
+			a.ttfbMin = ttfb
 		}
 	}
 }
 
-func (a aggregatedStats) point(op bench.Operation, noAggregate bool) *write.Point {
+func (a aggregatedStats) point(op bench.Operation) *write.Point {
 	p := influxdb2.NewPointWithMeasurement("warp")
 	p.AddTag("op", op.OpType)
 
-	if noAggregate {
-		p.AddField("requests", 1)
-		p.AddField("objects", op.ObjPerOp)
-		p.AddField("bytes_total", op.Size)
-		p.AddField("request_total_secs", float64(op.End.Sub(op.Start))/float64(time.Second))
-		if op.FirstByte != nil {
-			p.AddField("request_ttfb_avg_secs", float64(op.FirstByte.Sub(op.Start))/float64(time.Second))
-		}
-		errs := 0
-		if op.Err != "" {
-			errs = 1
-		}
-		p.AddField("errors", errs)
-		p.SetTime(op.End)
-	} else {
-		p.AddField("requests", a.ops)
-		p.AddField("objects", a.objects)
-		p.AddField("bytes_total", a.bytes)
-		p.AddField("errors", a.errors)
-		p.AddField("request_total_secs", float64(a.reqDur)/float64(time.Second))
-		if a.ttfb > 0 {
-			p.AddField("request_ttfb_total_secs", float64(a.ttfb)/float64(time.Second))
-		}
+	p.AddField("requests", a.incr.ops)
+	p.AddField("objects", a.incr.objects)
+	p.AddField("bytes_total", a.incr.bytes)
+	p.AddField("errors", a.incr.errors)
+	// Average
+	p.AddField("request_total_secs", (float64(a.incr.reqDur)/float64(time.Second))/float64(a.incr.ops))
+	if a.incr.ttfb > 0 {
+		// Average
+		p.AddField("request_ttfb_total_secs", (float64(a.incr.ttfb)/float64(time.Second))/float64(a.incr.ops))
 	}
+
 	return p
 }
 
 func (a aggregatedStats) summary(opType string) *write.Point {
 	p := influxdb2.NewPointWithMeasurement("warp_run_summary")
 	p.AddTag("op", opType)
-	p.AddField("requests", a.ops)
-	p.AddField("objects", a.objects)
-	p.AddField("bytes_total", a.bytes)
-	p.AddField("errors", a.errors)
-	p.AddField("request_total_secs", float64(a.reqDur)/float64(time.Second))
-	if a.ops-a.errors > 0 {
-		p.AddField("request_avg_secs", float64(a.reqDur)/float64(time.Second)/float64(a.ops-a.errors))
+	p.AddField("requests", a.total.ops)
+	p.AddField("objects", a.total.objects)
+	p.AddField("bytes_total", a.total.bytes)
+	p.AddField("errors", a.total.errors)
+	p.AddField("request_total_secs", float64(a.total.reqDur)/float64(time.Second))
+	if a.total.ops-a.total.errors > 0 {
+		p.AddField("request_avg_secs", float64(a.total.reqDur)/float64(time.Second)/float64(a.total.ops-a.total.errors))
 	}
 	p.AddField("request_min_secs", float64(a.reqMin)/float64(time.Second))
 	p.AddField("request_max_secs", float64(a.reqMax)/float64(time.Second))
-	if a.ttfb > 0 {
-		p.AddField("request_ttfb_total_secs", float64(a.ttfb)/float64(time.Second))
-		if a.ops-a.errors > 0 {
-			p.AddField("request_ttfb_avg_secs", float64(a.ttfb)/float64(time.Second)/float64(a.ops-a.errors))
-		}
+	if a.total.ttfb > 0 {
+		p.AddField("request_ttfb_avg_secs", float64(a.total.ttfb)/float64(time.Second)/float64(a.total.ops-a.total.errors))
 		p.AddField("request_ttfb_min_secs", float64(a.ttfbMin)/float64(time.Second))
 		p.AddField("request_ttfb_max_secs", float64(a.ttfbMax)/float64(time.Second))
 	}

--- a/pkg/generator/circular_random.go
+++ b/pkg/generator/circular_random.go
@@ -1,0 +1,178 @@
+package generator
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+)
+
+// CircularRandomOpts are the options for the circular random data source.
+type CircularRandomOpts struct {
+	seed *int64
+	size int
+}
+
+func WithCircularRandomData() CircularRandomOpts {
+	return CircularRandomOpts{
+		seed: nil,
+		// Use 2^20 + 1 (1MB + 1 byte) as default size
+		size: 1<<20 + 1,
+	}
+}
+
+// Apply Circular Random data options.
+func (o CircularRandomOpts) Apply() Option {
+	return func(opts *Options) error {
+		if err := o.validate(); err != nil {
+			return err
+		}
+		opts.circularRandom = o
+		opts.src = newCircularRandom
+		return nil
+	}
+}
+
+func (o CircularRandomOpts) validate() error {
+	if o.size <= 0 {
+		return fmt.Errorf("circular random: size must be > 0, got %d", o.size)
+	}
+	return nil
+}
+
+// RngSeed will set a fixed RNG seed to make usage predictable.
+func (o CircularRandomOpts) RngSeed(s int64) CircularRandomOpts {
+	o.seed = &s
+	return o
+}
+
+// Size will set the size of the circular buffer.
+func (o CircularRandomOpts) Size(s int) CircularRandomOpts {
+	o.size = s
+	return o
+}
+
+type circularRandomSrc struct {
+	buf []byte
+	rng *rand.Rand
+	obj Object
+	o   Options
+	pos int64
+}
+
+func newCircularRandom(o Options) (Source, error) {
+	rndSrc := rand.NewSource(int64(rand.Uint64()))
+	if o.circularRandom.seed != nil {
+		rndSrc = rand.NewSource(*o.circularRandom.seed)
+	}
+	rng := rand.New(rndSrc)
+
+	size := o.circularRandom.size
+	if size <= 0 {
+		return nil, fmt.Errorf("size must be > 0, got %d", size)
+	}
+
+	// Generate random data for the circular buffer
+	buf := make([]byte, size)
+	_, err := io.ReadFull(rng, buf)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &circularRandomSrc{
+		o:   o,
+		rng: rng,
+		buf: buf,
+		obj: Object{
+			Reader:      nil,
+			Name:        "",
+			ContentType: "application/octet-stream",
+			Size:        0,
+		},
+		pos: 0,
+	}
+	r.obj.setPrefix(o)
+	return r, nil
+}
+
+func (r *circularRandomSrc) Object() *Object {
+	var nBuf [16]byte
+	randASCIIBytes(nBuf[:], r.rng)
+	r.obj.Size = r.o.getSize(r.rng)
+	r.obj.setName(fmt.Sprintf("%s.crnd", string(nBuf[:])))
+
+	// Create a new reader for this object, continuing from the current position
+	r.obj.Reader = &circularReader{
+		buf:    r.buf,
+		pos:    r.pos,
+		end:    r.pos + r.obj.Size,
+		remain: r.obj.Size,
+	}
+
+	// Update the position for the next object
+	r.pos = (r.pos + r.obj.Size) % int64(len(r.buf))
+
+	return &r.obj
+}
+
+func (r *circularRandomSrc) String() string {
+	if r.o.randSize {
+		return fmt.Sprintf("Circular Random data; random size up to %d bytes", r.o.totalSize)
+	}
+	return fmt.Sprintf("Circular Random data; %d bytes total", r.o.totalSize)
+}
+
+func (r *circularRandomSrc) Prefix() string {
+	return r.obj.Prefix
+}
+
+type circularReader struct {
+	buf    []byte
+	pos    int64
+	end    int64
+	remain int64
+}
+
+func (cr *circularReader) Read(p []byte) (n int, err error) {
+	if cr.remain <= 0 {
+		return 0, io.EOF
+	}
+
+	if int64(len(p)) > cr.remain {
+		p = p[:cr.remain]
+	}
+
+	n = len(p)
+	for i := range p {
+		p[i] = cr.buf[cr.pos%int64(len(cr.buf))]
+		cr.pos++
+	}
+
+	cr.remain -= int64(n)
+	return n, nil
+}
+
+func (cr *circularReader) Seek(offset int64, whence int) (int64, error) {
+	var abs int64
+	switch whence {
+	case io.SeekStart:
+		abs = offset
+	case io.SeekCurrent:
+		abs = cr.pos - cr.end + cr.remain + offset
+	case io.SeekEnd:
+		abs = cr.remain + offset
+	default:
+		return 0, fmt.Errorf("invalid whence: %d", whence)
+	}
+
+	if abs < 0 {
+		return 0, fmt.Errorf("negative position: %d", abs)
+	}
+
+	if abs > cr.end-cr.pos {
+		cr.remain = 0
+		return cr.end - cr.pos, io.EOF
+	}
+
+	cr.remain = cr.end - cr.pos - abs
+	return abs, nil
+}

--- a/pkg/generator/options.go
+++ b/pkg/generator/options.go
@@ -27,14 +27,15 @@ import (
 // Options provides options.
 // Use WithXXX functions to set them.
 type Options struct {
-	src          func(o Options) (Source, error)
-	customPrefix string
-	random       RandomOpts
-	csv          CsvOpts
-	minSize      int64
-	totalSize    int64
-	randomPrefix int
-	randSize     bool
+	src            func(o Options) (Source, error)
+	customPrefix   string
+	random         RandomOpts
+	circularRandom CircularRandomOpts
+	csv            CsvOpts
+	minSize        int64
+	totalSize      int64
+	randomPrefix   int
+	randSize       bool
 
 	// Activates the use of a distribution of sizes
 	flagSizesDistribution bool
@@ -59,11 +60,12 @@ func (o Options) getSize(rng *rand.Rand) int64 {
 
 func defaultOptions() Options {
 	o := Options{
-		src:          newRandom,
-		totalSize:    1 << 20,
-		csv:          csvOptsDefaults(),
-		random:       randomOptsDefaults(),
-		randomPrefix: 0,
+		src:            newRandom,
+		totalSize:      1 << 20,
+		csv:            csvOptsDefaults(),
+		random:         randomOptsDefaults(),
+		circularRandom: WithCircularRandomData(),
+		randomPrefix:   0,
 	}
 	return o
 }


### PR DESCRIPTION
There are two improvements in this PR:

1. The original Influx code would send every transaction to Influx. Even with Influx's asynchronous writes, we were completely overwhelming the InfluxDB server at scale. This improvement introduces a one second timer and locally aggregates its own statistics so there's only a few writes per second. This reduces load on InfluxDB by many orders of magnitude and improves Grafana performance as well.

2. The default random code uses a circular buffer of random data that is then fed into AES-CBC to generate truly random data. Since we don't have any dedupe yet, this is likely overkill and consumes a lot of CPU at scale. You can now use `--generator:randomLite` to use a stripped-down random that simply uses a circular buffer of random per goroutine to populate the object data. Since it is reused, wraps, and is an odd size, the offset should be different for most objects and generate many different MD5s per goroutine.