### PR TITLE
REDSYSQE-475: Add MD5 checking support to the get command

### DIFF
--- a/cli/get.go
+++ b/cli/get.go
@@ -66,6 +66,10 @@ var getFlags = []cli.Flag{
 		Name:  "extra-head",
 		Usage: "Many apps HEAD before GET. Add an extra HEAD operation to emulate this behavior.",
 	},
+	cli.BoolFlag{
+		Name:  "md5",
+		Usage: "Verify MD5 hash of downloaded objects against ETag",
+	},
 }
 
 var getCmd = cli.Command{
@@ -111,6 +115,7 @@ func mainGet(ctx *cli.Context) error {
 		ListFlat:      ctx.Bool("list-flat"),
 		ListPrefix:    ctx.String("prefix"),
 		ExtraHead:     ctx.Bool("extra-head"),
+		VerifyMD5:     ctx.Bool("md5"),
 	}
 	if b.ListExisting && !ctx.IsSet("objects") {
 		b.CreateObjects = 0

--- a/cli/get.go
+++ b/cli/get.go
@@ -67,7 +67,7 @@ var getFlags = []cli.Flag{
 		Usage: "Many apps HEAD before GET. Add an extra HEAD operation to emulate this behavior.",
 	},
 	cli.BoolFlag{
-		Name:  "md5",
+		Name:  "verify-md5",
 		Usage: "Verify MD5 hash of downloaded objects against ETag",
 	},
 }
@@ -115,7 +115,7 @@ func mainGet(ctx *cli.Context) error {
 		ListFlat:      ctx.Bool("list-flat"),
 		ListPrefix:    ctx.String("prefix"),
 		ExtraHead:     ctx.Bool("extra-head"),
-		VerifyMD5:     ctx.Bool("md5"),
+		VerifyMD5:     ctx.Bool("verify-md5"),
 	}
 	if b.ListExisting && !ctx.IsSet("objects") {
 		b.CreateObjects = 0


### PR DESCRIPTION
Right now, there's no option for `warp get` to validate the Etag of objects returned. This adds a flag `--verify-md5` that will (when possible) calculate an MD5 of the object content and verify the Etag of the object.